### PR TITLE
Scope minimatch override under @eslint/config-array to fix broken lint

### DIFF
--- a/frontend/vite-project/package-lock.json
+++ b/frontend/vite-project/package-lock.json
@@ -2640,6 +2640,22 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",

--- a/frontend/vite-project/package.json
+++ b/frontend/vite-project/package.json
@@ -96,6 +96,9 @@
     "flatted": "^3.4.2",
     "picomatch": ">=2.3.2",
     "follow-redirects": "^1.16.0",
-    "path-to-regexp": ">=0.1.13"
+    "path-to-regexp": ">=0.1.13",
+    "@eslint/config-array": {
+      "minimatch": "^10.2.5"
+    }
   }
 }


### PR DESCRIPTION
The global brace-expansion override (forced to ^5.0.8 to close GHSA-mh99-v99m-4gvg) broke `npm run lint`: minimatch@3.1.5 (pulled in by @eslint/config-array@0.21.1, ESLint 9.39.2's own dependency) does `var expand = require('brace-expansion')`, expecting the whole export to be the callable function - brace-expansion 1.x's shape. brace-expansion 5.0.8's actual CJS export is an object ({ expand, ... }, a named export), so `expand(pattern)` threw "TypeError: expand is not a function".

Investigated whether a same-major patched brace-expansion release exists for the 1.x/2.x/3.x/4.x lines (would have let minimatch@3.1.5 keep its expected API shape): GHSA-mh99-v99m-4gvg's own advisory data shows vulnerable_versions "<=5.0.7", patched only ">=5.0.8" - no such release exists, so a same-major fix was not an option.

Fix: scope minimatch specifically under @eslint/config-array to ^10.2.5 via nested npm overrides, rather than reverting the brace-expansion override or bumping ESLint's major version. minimatch 10.x calls brace-expansion via the named `expand` export - the shape 5.0.8 actually has - so this resolves the mismatch directly. Confirmed via `npm ls` that only @eslint/config-array's minimatch changed; every other consumer (eslint-plugin-react, @eslint/eslintrc, the babel-jest/istanbul chain) still correctly resolves minimatch@3.1.5, untouched.

Verified with real output, not descriptions:
- npm run lint: exit 0, 163 files with findings, 488 warnings, 0 errors.
- Ignore-pattern matching specifically re-checked (the glob behavior most likely to silently regress across a minimatch major bump): `dist` is correctly excluded from lint output.
- Fresh npm audit (full and --omit=dev, matching the CI gate): single deduped brace-expansion copy at 5.0.8 across the whole tree, zero brace-expansion findings - only the already-scoped react-router RSC advisory (GHSA-qwww-vcr4-c8h2) remains, unchanged.
- audit-ci --config audit-ci.json: still exits 0.
- npm run build: still succeeds.